### PR TITLE
Make DurationAfterAppendAudio/Video tests work

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -384,7 +384,7 @@ void MediaSource::setDurationInternal(const MediaTime& duration)
     if (oldDuration.isValid() && duration < oldDuration) {
         for (SourceBufferList::const_iterator it = m_sourceBuffers->begin(); it != m_sourceBuffers->end(); ++it) {
             RefPtr<SourceBuffer> sourceBuffer = *it;
-            sourceBuffer->remove(duration, oldDuration, IGNORE_EXCEPTION);
+            sourceBuffer->remove(duration, oldDuration, IGNORE_EXCEPTION, true);
         }
     }
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -295,6 +295,34 @@ void SourceBuffer::appendBuffer(PassRefPtr<ArrayBufferView> data, ExceptionCode&
     appendBufferInternal(static_cast<unsigned char*>(data->baseAddress()), data->byteLength(), ec);
 }
 
+void SourceBuffer::resetParserState()
+{
+    // Section 3.5.2 Reset Parser State algorithm steps.
+    // http://www.w3.org/TR/2014/CR-media-source-20140717/#sourcebuffer-reset-parser-state
+    // 1. If the append state equals PARSING_MEDIA_SEGMENT and the input buffer contains some complete coded frames,
+    //    then run the coded frame processing algorithm until all of these complete coded frames have been processed.
+    // FIXME: If any implementation will work in pulling mode (instead of async push to SourceBufferPrivate, and forget)
+    //     this should be handled somehow either here, or in m_private->abort();
+
+    // 2. Unset the last decode timestamp on all track buffers.
+    // 3. Unset the last frame duration on all track buffers.
+    // 4. Unset the highest presentation timestamp on all track buffers.
+    // 5. Set the need random access point flag on all track buffers to true.
+    for (HashMap<AtomicString, TrackBuffer>::iterator::Values trackBufferPair = m_trackBufferMap.values().begin(); trackBufferPair != m_trackBufferMap.values().end(); ++trackBufferPair) {
+        trackBufferPair->lastDecodeTimestamp = MediaTime::invalidTime();
+        trackBufferPair->lastFrameDuration = MediaTime::invalidTime();
+        trackBufferPair->highestPresentationTimestamp = MediaTime::invalidTime();
+        trackBufferPair->needRandomAccessFlag = true;
+    }
+
+    // 6. Remove all bytes from the input buffer.
+    // Note: this is handled by abortIfUpdating()
+    // 7. Set append state to WAITING_FOR_SEGMENT.
+    m_appendState = WaitingForSegment;
+
+    m_private->abort();
+}
+
 void SourceBuffer::abort(ExceptionCode& ec)
 {
     // Section 3.2 abort() method steps.
@@ -312,7 +340,7 @@ void SourceBuffer::abort(ExceptionCode& ec)
     abortIfUpdating();
 
     // 4. Run the reset parser state algorithm.
-    m_private->abort();
+    resetParserState();
 
     // FIXME(229408) Add steps 5-6 update appendWindowStart & appendWindowEnd.
 }

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -345,12 +345,12 @@ void SourceBuffer::abort(ExceptionCode& ec)
     // FIXME(229408) Add steps 5-6 update appendWindowStart & appendWindowEnd.
 }
 
-void SourceBuffer::remove(double start, double end, ExceptionCode& ec)
+void SourceBuffer::remove(double start, double end, ExceptionCode& ec, bool sync)
 {
-    remove(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end), ec);
+    remove(MediaTime::createWithDouble(start), MediaTime::createWithDouble(end), ec, sync);
 }
 
-void SourceBuffer::remove(const MediaTime& start, const MediaTime& end, ExceptionCode& ec)
+void SourceBuffer::remove(const MediaTime& start, const MediaTime& end, ExceptionCode& ec, bool sync)
 {
     LOG(MediaSource, "SourceBuffer::remove(%p) - start(%lf), end(%lf)", this, start.toDouble(), end.toDouble());
 
@@ -384,7 +384,12 @@ void SourceBuffer::remove(const MediaTime& start, const MediaTime& end, Exceptio
     // 8. Return control to the caller and run the rest of the steps asynchronously.
     m_pendingRemoveStart = start;
     m_pendingRemoveEnd = end;
-    m_removeTimer.startOneShot(0);
+
+    if (sync) {
+        removeTimerFired(0);
+    } else {
+        m_removeTimer.startOneShot(0);
+    }
 }
 
 void SourceBuffer::abortIfUpdating()

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -82,8 +82,8 @@ public:
     void appendBuffer(PassRefPtr<ArrayBuffer> data, ExceptionCode&);
     void appendBuffer(PassRefPtr<ArrayBufferView> data, ExceptionCode&);
     void abort(ExceptionCode&);
-    void remove(double start, double end, ExceptionCode&);
-    void remove(const MediaTime&, const MediaTime&, ExceptionCode&);
+    void remove(double start, double end, ExceptionCode&, bool sync = false);
+    void remove(const MediaTime&, const MediaTime&, ExceptionCode&, bool sync = false);
 
     void abortIfUpdating();
     void removedFromMediaSource();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -175,6 +175,7 @@ private:
 
     void appendBufferInternal(unsigned char*, unsigned, ExceptionCode&);
     void appendBufferTimerFired(Timer<SourceBuffer>*);
+    void resetParserState();
 
     void setActive(bool);
 


### PR DESCRIPTION
This pull request makes the YouTube 2015 tests[1] #23 and #24 pass. Test #34 also works now.

http://yt-dash-mse-test.commondatastorage.googleapis.com/unit-tests/2015.html?timestamp=1421225302331