### PR TITLE
Fix building with glib 2.43+ (backport from qtwebkit 5.4.2)

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitWebSourceGStreamer.cpp
@@ -366,7 +366,7 @@ static void webKitWebSrcSetProperty(GObject* object, guint propID, const GValue*
 
     switch (propID) {
     case PROP_IRADIO_MODE: {
-        GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+        WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
         priv->iradioMode = g_value_get_boolean(value);
         break;
     }
@@ -388,7 +388,7 @@ static void webKitWebSrcGetProperty(GObject* object, guint propID, GValue* value
     WebKitWebSrc* src = WEBKIT_WEB_SRC(object);
     WebKitWebSrcPrivate* priv = src->priv;
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     switch (propID) {
     case PROP_IRADIO_MODE:
         g_value_set_boolean(value, priv->iradioMode);
@@ -442,7 +442,7 @@ static gboolean webKitWebSrcStop(WebKitWebSrc* src)
 
     ASSERT(isMainThread());
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     bool seeking = priv->seekID;
 
@@ -506,7 +506,7 @@ static gboolean webKitWebSrcStart(WebKitWebSrc* src)
 
     ASSERT(isMainThread());
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     priv->startID = 0;
     priv->corsAccessCheck = CORSNoCheck;
@@ -602,7 +602,7 @@ static GstStateChangeReturn webKitWebSrcChangeState(GstElement* element, GstStat
         return ret;
     }
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     switch (transition) {
     case GST_STATE_CHANGE_READY_TO_PAUSED:
         GST_DEBUG_OBJECT(src, "READY->PAUSED");
@@ -637,7 +637,7 @@ static gboolean webKitWebSrcQueryWithParent(GstPad* pad, GstObject* parent, GstQ
         gst_query_parse_duration(query, &format, NULL);
 
         GST_DEBUG_OBJECT(src, "duration query in format %s", gst_format_get_name(format));
-        GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+        WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
         if (format == GST_FORMAT_BYTES && src->priv->size > 0) {
             gst_query_set_duration(query, format, src->priv->size);
             result = TRUE;
@@ -645,7 +645,7 @@ static gboolean webKitWebSrcQueryWithParent(GstPad* pad, GstObject* parent, GstQ
         break;
     }
     case GST_QUERY_URI: {
-        GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+        WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
         gst_query_set_uri(query, src->priv->uri);
         result = TRUE;
         break;
@@ -699,7 +699,7 @@ static gchar* webKitWebSrcGetUri(GstURIHandler* handler)
     WebKitWebSrc* src = WEBKIT_WEB_SRC(handler);
     gchar* ret;
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     ret = g_strdup(src->priv->uri);
     return ret;
 }
@@ -714,7 +714,7 @@ static gboolean webKitWebSrcSetUri(GstURIHandler* handler, const gchar* uri, GEr
         return FALSE;
     }
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     g_free(priv->uri);
     priv->uri = 0;
@@ -750,7 +750,7 @@ static const gchar* webKitWebSrcGetUri(GstURIHandler* handler)
     WebKitWebSrc* src = WEBKIT_WEB_SRC(handler);
     gchar* ret;
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     ret = g_strdup(src->priv->uri);
     return ret;
 }
@@ -765,7 +765,7 @@ static gboolean webKitWebSrcSetUri(GstURIHandler* handler, const gchar* uri)
         return FALSE;
     }
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     g_free(priv->uri);
     priv->uri = 0;
@@ -803,7 +803,7 @@ static gboolean webKitWebSrcNeedDataMainCb(WebKitWebSrc* src)
 
     ASSERT(isMainThread());
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     // already stopped
     if (!priv->needDataID)
         return FALSE;
@@ -824,7 +824,7 @@ static void webKitWebSrcNeedDataCb(GstAppSrc*, guint length, gpointer userData)
 
     GST_DEBUG_OBJECT(src, "Need more data: %u", length);
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     if (priv->needDataID || !priv->paused) {
         return;
     }
@@ -839,7 +839,7 @@ static gboolean webKitWebSrcEnoughDataMainCb(WebKitWebSrc* src)
 
     ASSERT(isMainThread());
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     // already stopped
     if (!priv->enoughDataID)
         return FALSE;
@@ -860,7 +860,7 @@ static void webKitWebSrcEnoughDataCb(GstAppSrc*, gpointer userData)
 
     GST_DEBUG_OBJECT(src, "Have enough data");
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     if (priv->enoughDataID || priv->paused) {
         return;
     }
@@ -876,7 +876,7 @@ static gboolean webKitWebSrcSeekMainCb(WebKitWebSrc* src)
 
     ASSERT(isMainThread());
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     // already stopped
     if (!priv->seekID)
         return FALSE;
@@ -894,7 +894,7 @@ static gboolean webKitWebSrcSeekDataCb(GstAppSrc*, guint64 offset, gpointer user
     WebKitWebSrcPrivate* priv = src->priv;
 
     GST_DEBUG_OBJECT(src, "Seeking to offset: %" G_GUINT64_FORMAT, offset);
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     if (offset == priv->offset && priv->requestedOffset == priv->offset)
         return TRUE;
 
@@ -915,7 +915,7 @@ static gboolean webKitWebSrcSeekDataCb(GstAppSrc*, guint64 offset, gpointer user
 void webKitWebSrcSetMediaPlayer(WebKitWebSrc* src, WebCore::MediaPlayer* player)
 {
     ASSERT(player);
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     src->priv->player = player;
     s_cachedResourceLoader = player->cachedResourceLoader();
 }
@@ -948,7 +948,7 @@ char* StreamingClient::createReadBuffer(size_t requestedSize, size_t& actualSize
     mapGstBuffer(buffer);
 #endif
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     priv->buffer = adoptGRef(buffer);
     locker.unlock();
 
@@ -974,7 +974,7 @@ void StreamingClient::handleResponseReceived(const ResourceResponse& response, C
         return;
     }
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     priv->corsAccessCheck = corsAccessCheck;
 
@@ -1090,7 +1090,7 @@ void StreamingClient::handleDataReceived(const char* data, int length)
     WebKitWebSrc* src = WEBKIT_WEB_SRC(m_src);
     WebKitWebSrcPrivate* priv = src->priv;
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
 
     GST_LOG_OBJECT(src, "Have %d bytes of data", priv->buffer ? getGstBufferSize(priv->buffer.get()) : length);
 
@@ -1165,7 +1165,7 @@ void StreamingClient::handleNotifyFinished()
 
     GST_DEBUG_OBJECT(src, "Have EOS");
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     if (!priv->seekID) {
         locker.unlock();
         gst_app_src_end_of_stream(priv->appsrc);
@@ -1316,7 +1316,7 @@ void ResourceHandleStreamingClient::wasBlocked(ResourceHandle*)
 
     GST_ERROR_OBJECT(src, "Request was blocked");
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     uri.set(g_strdup(src->priv->uri));
     locker.unlock();
 
@@ -1330,7 +1330,7 @@ void ResourceHandleStreamingClient::cannotShowURL(ResourceHandle*)
 
     GST_ERROR_OBJECT(src, "Cannot show URL");
 
-    GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
+    WebCore::GMutexLocker locker(GST_OBJECT_GET_LOCK(src));
     uri.set(g_strdup(src->priv->uri));
     locker.unlock();
 


### PR DESCRIPTION
The newest version of glib have introduced their own GMutexLocker
conflicting with the one defined in WebCore.

Task-number: QTBUG-44714
Change-Id: Ibdd1646e129eaed84c65dc0d96bebe80f2a61f4b
Reviewed-by: Andras Becsi <andras.becsi@theqtcompany.com>