### PR TITLE
Fix g++ 5.0 build

### DIFF
--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -1909,6 +1909,11 @@ void JSObject::putByIndexBeyondVectorLengthWithoutAttributes(ExecState* exec, un
     }
 }
 
+// Used in JSArray.cpp so we must instantiate explicit
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<Int32Shape>(ExecState* exec, unsigned i, JSValue value);
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<DoubleShape>(ExecState* exec, unsigned i, JSValue value);
+template void JSObject::putByIndexBeyondVectorLengthWithoutAttributes<ContiguousShape>(ExecState* exec, unsigned i, JSValue value);
+
 void JSObject::putByIndexBeyondVectorLengthWithArrayStorage(ExecState* exec, unsigned i, JSValue value, bool shouldThrow, ArrayStorage* storage)
 {
     VM& vm = exec->vm();


### PR DESCRIPTION
A non-inline template needs to be explicitly instantiated if used
outside the object where it is declared.

Patch suggested by Khem Raj.

Task-number: QTBUG-44829
Change-Id: Ib0adbd9273bd1cef01e5863bc8aaa9c373022792
Reviewed-by: Andras Becsi andras.becsi@theqtcompany.com
