### PR TITLE
Fixed processing local files.

### DIFF
--- a/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
+++ b/Source/WebCore/platform/network/qt/QNetworkReplyHandler.cpp
@@ -384,12 +384,16 @@ void QNetworkReplyWrapper::replyDestroyed()
 void QNetworkReplyWrapper::emitMetaDataChanged()
 {
     QueueLocker lock(m_queue);
-    m_queue->push(&QNetworkReplyHandler::sendResponseIfNeeded);
 
     if (m_reply->bytesAvailable()) {
         m_responseContainsData = true;
         m_queue->push(&QNetworkReplyHandler::forwardData);
     }
+
+    // In case if m_reply is about local file and sendResponseIfNeeded has been applied before forwardData (or whatever),
+    // all subsequent calls in queue will never be called (e.g. and no data will be read)
+    // due to m_queue is cleared within destruction of current QNetworkReplyWrapper object.
+    m_queue->push(&QNetworkReplyHandler::sendResponseIfNeeded);
 
     if (isFinished()) {
         m_queue->push(&QNetworkReplyHandler::finish);

--- a/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
+++ b/Source/WebKit/qt/WebCoreSupport/QWebFrameAdapter.cpp
@@ -378,15 +378,19 @@ QUrl QWebFrameAdapter::ensureAbsoluteUrl(const QUrl& url)
     if (!validatedUrl.isValid() || !validatedUrl.isRelative())
         return validatedUrl;
 
+    // Since validatedUrl is not relative url (no schema provided)
+    // we are working with file context and need to explicitly specify this.
+    // Otherwise toLocalFile() will return empty string
+    // due to it requires url as local file (i.e. with "file" schema).
+    validatedUrl.setScheme("file");
+
     // This contains the URL with absolute path but without
     // the query and the fragment part.
     QUrl baseUrl = QUrl::fromLocalFile(QFileInfo(validatedUrl.toLocalFile()).absoluteFilePath());
+    baseUrl.setFragment(validatedUrl.fragment());
+    baseUrl.setQuery(validatedUrl.query());
 
-    // The path is removed so the query and the fragment parts are there.
-    QString pathRemoved = validatedUrl.toString(QUrl::RemovePath);
-    QUrl toResolve(pathRemoved);
-
-    return baseUrl.resolved(toResolve);
+    return baseUrl;
 }
 
 QWebHitTestResultPrivate* QWebFrameAdapter::hitTestContent(const QPoint& pos) const


### PR DESCRIPTION
Fixed a bug with processing urls with file schema.
1. Fixed QWebFrameAdapter::ensureAbsoluteUrl where was a bug to retreive absolute path
if url without schema provided.
2. Changed sequence of adding calls to QNetworkReplyWrapper::QNetworkReplyHandlerCallQueue.
Calling sendResponseIfNeeded before forwardData could lead processing MainResourceLoader::didReceiveResponse which could cause calling FrameLoaderClientQt::download where current QNetworkReplyHandler will be released with exact reply handler call queue including unprocessed yet subsequent calls (e.g. forwardData where data read is handled).
