### PR TITLE
JITStubs.cpp: fix MIPS ctiVMThrowTrampoline() relocation overflow

### DIFF
--- a/Source/JavaScriptCore/jit/JITStubs.cpp
+++ b/Source/JavaScriptCore/jit/JITStubs.cpp
@@ -589,7 +589,7 @@ SYMBOL_STRING(ctiVMThrowTrampoline) ":" "\n"
 ".cpload $31" "\n"
     "la    $25," SYMBOL_STRING(cti_vm_throw) "\n"
 ".set nomacro" "\n"
-    "bal " SYMBOL_STRING(cti_vm_throw) "\n"
+    "jalr  $25" "\n"
     "move  $4,$29" "\n"
 #else
     "jal " SYMBOL_STRING(cti_vm_throw) "\n"


### PR DESCRIPTION
Fix for MIPS ctiVMThrowTrampoline() relocation overflow build error:

 | linking ../lib/libQt5WebKit.so.5.4.1
 | /.../tmp/work/mips32el-rdk-linux/qtwebkit/5.4.1+metro+gitAUTOINC+dcacbc49cc-r0/build/Source/JavaScriptCore//libJavaScriptCore.a(/.../tmp/work/mips32el-rdk-linux/qtwebkit/5.4.1+metro+gitAUTOINC+dcacbc49cc-r0/build/Source/JavaScriptCore//.obj/jit/JITStubs.o):JITStubs.cpp:function ctiVMThrowTrampoline: error: relocation overflow
 | collect2: error: ld returned 1 exit status
 | make[2]: **\* [../lib/libQt5WebKit.so.5.4.1] Error 1

Fix tested by confirming that the Octane 2.0 JavaScript benchmark
runs without errors with breakpoints in ctiVMThrowTrampoline() used
to confirm test coverage.

  Breakpoint 1, 0x0069a7c0 in ctiVMThrowTrampoline ()
  (gdb) bt
  #0  0x0069a7c0 in ctiVMThrowTrampoline ()
  #1  0x0069a7b8 in ctiTrampoline ()
  #2  0x0064ba84 in JSC::Interpreter::execute(JSC::ProgramExecutable_, JSC::ExecState_, JSC::JSObject_) ()
  #3  0x00799abc in JSC::evaluate(JSC::ExecState_, JSC::SourceCode const&, JSC::JSValue, JSC::JSValue_) ()
  #4  0x0042e2dc in jscmain(int, char_*) ()
  #5  0x0042fa00 in main ()

The offending code was remove from Webkit in 2013, so the only
upstream for this patch is qtwebkit.

  https://github.com/Metrological/qtwebkit/blob/qt5.4/Source/JavaScriptCore/jit/JITStubs.cpp#L592
  https://github.com/Metrological/WebKitForWayland/commit/bdfcf6ac1627e2ecf0553f5b05bdcedd950aaf5d#diff-2b4225b6f02ff83d4a12f7a00c3c4338L112

Signed-off-by: Andre McCurdy armccurdy@gmail.com
